### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/resources/json/issue-created.json
+++ b/src/main/resources/json/issue-created.json
@@ -145,7 +145,7 @@
     "ssh_url": "git@github.com:spring-cloud/spring-cloud-netflix.git",
     "clone_url": "https://github.com/spring-cloud/spring-cloud-netflix.git",
     "svn_url": "https://github.com/spring-cloud/spring-cloud-netflix",
-    "homepage": "http://cloud.spring.io/spring-cloud-netflix/",
+    "homepage": "https://cloud.spring.io/spring-cloud-netflix/",
     "size": 6756,
     "stargazers_count": 333,
     "watchers_count": 333,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-netflix/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-netflix/ ([https](https://cloud.spring.io/spring-cloud-netflix/) result 200).